### PR TITLE
Stabilize recorder timing and cleanup phone styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,9 +12,6 @@
       transition: opacity 1s ease-in-out;
     }
     
-    .phone {
-      transition: transform 1s ease-in-out, filter 1.5s ease-out;
-    }
     
     .transition-overlay {
       position: fixed;

--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
   <div class="phone">
     <!-- Statusleiste -->
     <div class="status-bar">
-      <div>17:42</div>
+      <div id="time">17:42</div>
       <div>📶 🔋</div>
     </div>
 

--- a/public/intro.html
+++ b/public/intro.html
@@ -2,7 +2,7 @@
 <html lang="de">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>🔥 VIRAL AI CHAT INTRO (TikTok Optimized)</title>
   <style>
     * {
@@ -23,8 +23,8 @@
     }
 
     .tiktok-container {
-      width: 375px;
-      height: 667px;
+      width: 360px;
+      height: 640px;
       position: relative;
       overflow: hidden;
       background: #000;

--- a/public/outro.html
+++ b/public/outro.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Outro</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="phone"></div>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -101,8 +101,17 @@
       const response = await fetch(CFG.DATA_URL);
       const {conversation} = await response.json();
       await playChat(conversation);
+      window.__IM_DONE__ = true;
     } catch (e) {
       console.error('Fehler:', e);
     }
   })();
+
+  setInterval(() => {
+    const el = document.getElementById("time");
+    if (el) {
+      const d = new Date();
+      el.textContent = d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    }
+  }, 1000);
 })();

--- a/public/style.css
+++ b/public/style.css
@@ -19,8 +19,8 @@ body {
 
 /* ===== PHONE-CONTAINER ===== */
 .phone {
-  width: 375px;
-  height: 667px;
+  width: 360px;
+  height: 640px;
   background: #000;
   border-radius: 40px;
   overflow: hidden;

--- a/record/record_mac.js
+++ b/record/record_mac.js
@@ -8,10 +8,12 @@ const { PuppeteerScreenRecorder } = require('puppeteer-screen-recorder');
 const CFG = {
   INTRO_URL: 'http://localhost:53694/intro.html',
   MAIN_URL: 'http://localhost:53694/index.html',
+  OUTRO_URL: 'http://localhost:53694/outro.html',
   OUT_DIR: path.join(__dirname, 'data'),
   FPS: 60,
-  VIEWPORT: { width: 375, height: 667, deviceScaleFactor: 2 },
-  INTRO_DURATION: 2500,
+  VIEWPORT: { width: 360, height: 640, deviceScaleFactor: 2 },
+  INTRO_DURATION: 3400,
+  OUTRO_DURATION: 5200,
   MIN_DURATION: 10000,
   MAX_DURATION: 300000,
   INACTIVITY_DELAY: 5000,
@@ -35,7 +37,17 @@ async function ensureDirectory(dir) {
 }
 
 async function recordPage(url, outputPath, duration, isMainPage = false) {
-  const browser = await puppeteer.launch({ headless: true });
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: [
+      "--no-sandbox",
+      "--disable-setuid-sandbox",
+      "--disable-dev-shm-usage",
+      "--disable-background-timer-throttling",
+      "--disable-renderer-backgrounding",
+      "--autoplay-policy=no-user-gesture-required"
+    ]
+  });
   const page = await browser.newPage();
   await page.setViewport(CFG.VIEWPORT);
 
@@ -92,6 +104,9 @@ async function recordPage(url, outputPath, duration, isMainPage = false) {
         lastActivity = currentTime;
         log(`💬 Aktivität: ${messageCount} Nachrichten` + (isTyping ? " (Typing...)" : ""));
       }
+
+      const done = await page.evaluate(() => !!window.__IM_DONE__);
+      if (done) break;
 
       // Beendigungskriterien
       if (duration >= CFG.MAX_DURATION) {
@@ -191,40 +206,40 @@ async function getVideoDuration(file) {
 }
 
 (async () => {
-  let introVideo, mainVideo, finalVideo;
+  let introVideo, mainVideo, outroVideo, finalVideo;
   let audioProcess;
 
   try {
-    // 1. Verzeichnis sicherstellen
     await ensureDirectory(CFG.OUT_DIR);
     const timestamp = Date.now();
     finalVideo = path.join(CFG.OUT_DIR, `final_${timestamp}.mp4`);
 
-    // 2. Audio-Aufnahme starten
     const audioResult = await recordAudio(path.join(CFG.OUT_DIR, `audio_${timestamp}.m4a`));
     audioProcess = audioResult.process;
 
-    // 3. Intro aufnehmen
     introVideo = await recordPage(
       CFG.INTRO_URL,
       path.join(CFG.OUT_DIR, `intro_${timestamp}.mp4`),
       CFG.INTRO_DURATION
     );
 
-    // 4. Hauptchat aufnehmen
     mainVideo = await recordPage(
       CFG.MAIN_URL,
       path.join(CFG.OUT_DIR, `main_${timestamp}.mp4`),
-      0, // Dauer wird intern berechnet
-      true // isMainPage flag
+      0,
+      true
     );
 
-    // 5. Audio stoppen
+    outroVideo = await recordPage(
+      CFG.OUTRO_URL,
+      path.join(CFG.OUT_DIR, `outro_${timestamp}.mp4`),
+      CFG.OUTRO_DURATION
+    );
+
     audioProcess.kill('SIGINT');
     await audioResult.promise;
 
-    // 6. Videos zusammenfügen
-    await mergeVideos([introVideo, mainVideo], audioResult.outputPath, finalVideo);
+    await mergeVideos([introVideo, mainVideo, outroVideo], audioResult.outputPath, finalVideo);
 
     log(`
 ✅ Aufnahme erfolgreich!
@@ -236,9 +251,8 @@ async function getVideoDuration(file) {
     error(`Hauptprozess fehlgeschlagen: ${err.message}`);
     process.exit(1);
   } finally {
-    // Aufräumen
     if (audioProcess) audioProcess.kill();
-    [introVideo, mainVideo].forEach(file => {
+    [introVideo, mainVideo, outroVideo].forEach(file => {
       if (file && fs.existsSync(file)) fs.unlinkSync(file);
     });
   }


### PR DESCRIPTION
## Summary
- add stable Chromium flags and outro recording with deterministic stop
- expose completion flag and optional clock update in chat script
- ensure consistent 9:16 frame with 360×640 viewport and matching intro container

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node record/record_mac.js` *(passes)*
- `ffprobe -v error -show_entries stream=width,height -of csv=p=0 record/data/final_1754915181603.mp4`

------
https://chatgpt.com/codex/tasks/task_e_6899dd0e0ce0832db5cf695becd5ce01